### PR TITLE
cgroup: Remove Dead codes, Due to the bad merge from the CAF

### DIFF
--- a/include/linux/cgroup.h
+++ b/include/linux/cgroup.h
@@ -615,8 +615,6 @@ struct cgroup_subsys {
 	void (*css_free)(struct cgroup_subsys_state *css);
 	void (*css_reset)(struct cgroup_subsys_state *css);
 
-	int (*allow_attach)(struct cgroup_subsys_state *css,
-			    struct cgroup_taskset *tset);
 	int (*can_attach)(struct cgroup_subsys_state *css,
 			  struct cgroup_taskset *tset);
 	void (*cancel_attach)(struct cgroup_subsys_state *css,
@@ -914,16 +912,6 @@ struct cgroup_subsys_state *css_tryget_online_from_dir(struct dentry *dentry,
 						       struct cgroup_subsys *ss);
 int cgroup_attach_task_to_root(struct task_struct *tsk, int wait);
 
-/*
- * Default Android check for whether the current process is allowed to move a
- * task across cgroups, either because CAP_SYS_NICE is set or because the uid
- * of the calling process is the same as the moved task or because we are
- * running as root.
- * Returns 0 if this is allowed, or -EACCES otherwise.
- */
-int subsys_cgroup_allow_attach(struct cgroup_subsys_state *css,
-			       struct cgroup_taskset *tset);
-
 #else /* !CONFIG_CGROUPS */
 
 static inline int cgroup_init_early(void) { return 0; }
@@ -943,12 +931,6 @@ static inline int cgroup_attach_task_all(struct task_struct *from,
 					 struct task_struct *t)
 {
 	return 0;
-}
-
-static inline int subsys_cgroup_allow_attach(struct cgroup_subsys_state *css,
-					     void *tset)
-{
-	return -EINVAL;
 }
 
 static inline int cgroup_attach_task_to_root(struct task_struct *tsk, int wait)

--- a/kernel/cgroup.c
+++ b/kernel/cgroup.c
@@ -2327,25 +2327,6 @@ static int cgroup_attach_task(struct cgroup *dst_cgrp,
 	return ret;
 }
 
-int subsys_cgroup_allow_attach(struct cgroup_subsys_state *css, struct cgroup_taskset *tset)
-{
-	const struct cred *cred = current_cred(), *tcred;
-	struct task_struct *task;
-
-	if (capable(CAP_SYS_NICE))
-		return 0;
-
-	cgroup_taskset_for_each(task, tset) {
-		tcred = __task_cred(task);
-
-		if (current != task && !uid_eq(cred->euid, tcred->uid) &&
-		    !uid_eq(cred->euid, tcred->suid))
-			return -EACCES;
-	}
-
-	return 0;
-}
-
 /*
  * Find the task_struct of the task to attach by vpid and pass it along to the
  * function to attach either it or all tasks in its threadgroup. Will lock

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -12009,7 +12009,6 @@ struct cgroup_subsys cpu_cgrp_subsys = {
 	.fork		= cpu_cgroup_fork,
 	.can_attach	= cpu_cgroup_can_attach,
 	.attach		= cpu_cgroup_attach,
-	.allow_attach   = subsys_cgroup_allow_attach,
 	.exit		= cpu_cgroup_exit,
 	.legacy_cftypes	= cpu_files,
 	.early_init	= 1,


### PR DESCRIPTION
* CAF's left these codes without removing them after merging of android-common & Linaro
  Therefore it is not necessary to exist.

* Reference:
 - https://github.com/aosp-mirror/kernel_common/commit/64a33c513f993c805eb75086cd024be1c0a48640
 - https://github.com/aosp-mirror/kernel_common/commit/7ec2568cc9a85f910ca46b73de66d684a8517886
 - https://github.com/aosp-mirror/kernel_common/commit/127fda861c235236901d2220f8a981930ac5ba97

Fixes: 99d31966cb90126004effbb343da0478ab3034d3 (Merge tag 'lsk-v3.18-17.03-android' into 'msm-3.18')
Signed-off-by: ahmedradaideh <ahmed.radaideh@gmail.com>